### PR TITLE
Fee estimation uses incorrect Order of operations

### DIFF
--- a/packages/bitcoin/src/htlc/utils.ts
+++ b/packages/bitcoin/src/htlc/utils.ts
@@ -61,7 +61,7 @@ export const getSwapPaymentVariants = (swapOutput: any, network: any) => {
 };
 
 export const calculateFee = (numInputs: number, numOutputs: number, feePerByte: number) => {
-    return (numInputs * 148 + numOutputs * 34 + 10) * feePerByte; // TODO: fix this magic :X
+		return ((numInputs * 148) + (numOutputs * 34) + 10) * feePerByte
 };
 
 const getPubKeyHash = (address: string) => {

--- a/packages/bitcoin/src/htlc/utils.ts
+++ b/packages/bitcoin/src/htlc/utils.ts
@@ -61,7 +61,7 @@ export const getSwapPaymentVariants = (swapOutput: any, network: any) => {
 };
 
 export const calculateFee = (numInputs: number, numOutputs: number, feePerByte: number) => {
-		return ((numInputs * 148) + (numOutputs * 34) + 10) * feePerByte
+    return ((numInputs * 148) + (numOutputs * 34) + 10) * feePerByte;
 };
 
 const getPubKeyHash = (address: string) => {


### PR DESCRIPTION
https://github.com/liquality/chainabstractionlayer/blob/78a540875e1c46ac1e402f93f3c15eabb70f0f26/packages/bitcoin-utils/lib/index.js#L9